### PR TITLE
enable ioncube extension for cli version of php 5.6 & 7.0

### DIFF
--- a/ansible/roles/ioncube/tasks/main.yml
+++ b/ansible/roles/ioncube/tasks/main.yml
@@ -15,10 +15,17 @@
     src: "/tmp/ioncube/ioncube_loader_lin_5.6.so"
     dest: "/usr/lib/php/20131226/"
     
-- name: Add Ioncube 5.6 to php.ini
+- name: Add Ioncube 5.6 to Apache2 php.ini
   become: yes
   become_method: sudo
   lineinfile: dest=/etc/php/5.6/apache2/php.ini line="zend_extension = /usr/lib/php/20131226/ioncube_loader_lin_5.6.so" insertafter=EOF state=present
+  notify:
+    - apache-restart
+    
+- name: Add Ioncube 5.6 to CLI php.ini
+  become: yes
+  become_method: sudo
+  lineinfile: dest=/etc/php/5.6/cli/php.ini line="zend_extension = /usr/lib/php/20131226/ioncube_loader_lin_5.6.so" insertafter=EOF state=present
   notify:
     - apache-restart
 
@@ -29,9 +36,16 @@
     src: "/tmp/ioncube/ioncube_loader_lin_7.0.so"
     dest: "/usr/lib/php/20151012/"
 
-- name: Add Ioncube 7.0 to php.ini
+- name: Add Ioncube 7.0 to Apache2 php.ini
   become: yes
   become_method: sudo
   lineinfile: dest=/etc/php/7.0/apache2/php.ini line="zend_extension = /usr/lib/php/20151012/ioncube_loader_lin_7.0.so" insertafter=EOF state=present
+  notify:
+    - apache-restart
+
+- name: Add Ioncube 7.0 to CLI php.ini
+  become: yes
+  become_method: sudo
+  lineinfile: dest=/etc/php/7.0/cli/php.ini line="zend_extension = /usr/lib/php/20151012/ioncube_loader_lin_7.0.so" insertafter=EOF state=present
   notify:
     - apache-restart


### PR DESCRIPTION
During development you often want to use the cli version of php to execute shopware console commands.
This PR enables the ioncube extension both for PHP 5 & 7.