### PR TITLE
Require vagrant >= 1.8.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Vagrant.require_version ">= 1.8.0"
+
 Vagrant.configure("2") do |config|
     config.ssh.forward_agent = true
 


### PR DESCRIPTION
The ansible_local provisioner has been added with Vagrant 1.8.0.

Requiring the right vagrant-version may prevent confusion about why the provisioning won't work.

(It confused me at least)