### PR TITLE
Vagrant-Hostmanager, Grunt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,8 @@ Vagrant.configure("2") do |config|
     config.vm.box_url = "https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box"
 
     config.vm.network :private_network, ip: "192.168.33.10"
+    config.vm.network "forwarded_port", guest: 8000, host: 8094
+    config.vm.network "forwarded_port", guest: 35729, host: 35729
 
     config.vm.hostname = "shopware.local"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure("2") do |config|
     #config.vm.synced_folder "../src", "/home/vagrant/www/shopware", create: true;
 
     config.vm.provider :virtualbox do |vb|
+        vb.name = "vagrant_shopware";
         vb.customize ["modifyvm", :id, "--cpus", 4]
         vb.customize ["modifyvm", :id, "--ioapic", "on"]
         vb.customize ["modifyvm", :id, "--memory", 2048]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,12 @@
 Vagrant.require_version ">= 1.8.0"
 
 Vagrant.configure("2") do |config|
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.manage_guest = true
+    config.hostmanager.ignore_private_ip = false
+    config.hostmanager.include_offline = true
+
     config.ssh.forward_agent = true
 
     config.vm.box = "ubuntu/trusty64"


### PR DESCRIPTION
Proposing some minor changes to add support for [Vagrant Hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) and port forwarding to allow Grunt & [LiveReload](http://livereload.com/) to work out of the box. ;)