### PR TITLE
Minor improvement to xdebug config

### DIFF
--- a/ansible/roles/apache/templates/99-debug.ini
+++ b/ansible/roles/apache/templates/99-debug.ini
@@ -1,5 +1,5 @@
+xdebug.remote_enable=1
+xdebug.remote_connect_back=1
 memory_limit=1024M
-opcache.revalidate_freq=0
 max_execution_time=300
-xdebug.remote_enable=On
-xdebug.remote_host=192.168.33.1
+opcache.revalidate_freq=0


### PR DESCRIPTION
Just a minor improvement to the xdebug configuration, so that you do not have enter any IP in the settings each time you provision the vagrant machine.