### PR TITLE
Added helpful debugging scripts

### DIFF
--- a/ansible/roles/common/files/bin/php-dbg
+++ b/ansible/roles/common/files/bin/php-dbg
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+php -d'xdebug.remote_autostart=On' -d'xdebug.remote_host=10.0.2.2' "$@"
+

--- a/ansible/roles/common/files/bin/php_5.6-dbg
+++ b/ansible/roles/common/files/bin/php_5.6-dbg
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+/usr/bin/php5.6 -d'xdebug.remote_autostart=On' -d'xdebug.remote_host=10.0.2.2' "$@"
+

--- a/ansible/roles/common/files/bin/php_5.6-dbg
+++ b/ansible/roles/common/files/bin/php_5.6-dbg
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-/usr/bin/php5.6 -d'xdebug.remote_autostart=On' -d'xdebug.remote_host=10.0.2.2' "$@"
-

--- a/ansible/roles/common/files/bin/php_7.0-dbg
+++ b/ansible/roles/common/files/bin/php_7.0-dbg
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+/usr/bin/php7.0 -d'xdebug.remote_autostart=On' -d'xdebug.remote_host=10.0.2.2' "$@"
+

--- a/ansible/roles/common/files/bin/php_7.1-dbg
+++ b/ansible/roles/common/files/bin/php_7.1-dbg
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+/usr/bin/php7.1 -d'xdebug.remote_autostart=On' -d'xdebug.remote_host=10.0.2.2' "$@"
+

--- a/ansible/roles/common/files/bin/php_7.2-dbg
+++ b/ansible/roles/common/files/bin/php_7.2-dbg
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+/usr/bin/php7.2 -d'xdebug.remote_autostart=On' -d'xdebug.remote_host=10.0.2.2' "$@"
+


### PR DESCRIPTION
These scripts make it possible to simply type `php-dbg` which  makes it easy to debug unittests from vagrant or the shopware cli:
* `cd www/shopware/tests && php-dbg ../vendor/bin/phpunit UnitTest Functional/Bundle/StoreFrontBundle/ConfiguratorTest.php`
* `php-dbg www/shopware/bin/console sw:cache:clear`