### PR TITLE
Added missing debug ini copies for php 7.2

### DIFF
--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -127,6 +127,7 @@
     - { file: '99-debug.ini', phpversion: '5.6'}
     - { file: '99-debug.ini', phpversion: '7.0'}
     - { file: '99-debug.ini', phpversion: '7.1'}
+    - { file: '99-debug.ini', phpversion: '7.2'}
   become: yes
   notify:
     - apache-restart
@@ -137,6 +138,7 @@
     - { file: '99-debug.ini', phpversion: '5.6'}
     - { file: '99-debug.ini', phpversion: '7.0'}
     - { file: '99-debug.ini', phpversion: '7.1'}
+    - { file: '99-debug.ini', phpversion: '7.2'}
   become: yes
 
 - name: Set PHP version


### PR DESCRIPTION
When you change to php 7.2 you cannot debug anymore using xdebug like you did it on php 7.1. This is due to missing files. 