### PR TITLE
fixed: state must be: absent, build-dep, fixed, latest, present, got: installed

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -33,7 +33,7 @@
   template: src=tmux.conf dest=~/.tmux.conf
 
 - name: be sure ntp is installed
-  apt: pkg=ntp state=installed
+  apt: pkg=ntp state=present
   tags: ntp
   become: yes
 


### PR DESCRIPTION
When creating a new vagrant machine I got this error:
`TASK [common : be sure ntp is installed] ***************************************
fatal: [shopware_vagrant]: FAILED! => {"changed": false, "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}`

This was discussed and fixed for **ntpd** [here ](https://github.com/shopwareLabs/shopware-vagrant/issues/45)

Now similar error occured for **ntp**.
I allready fixed this by setting the correct param **present**
