### PR TITLE
#56 extended the ioncube task for PHP 7.1 and 7.2

### DIFF
--- a/ansible/roles/ioncube/tasks/main.yml
+++ b/ansible/roles/ioncube/tasks/main.yml
@@ -72,3 +72,67 @@
     dest: /etc/php/7.0/cli/conf.d/0-ioncube.ini
     state: link
   tags: ioncube
+
+- name: Copy Ioncube 7.1
+  become: yes
+  become_method: sudo
+  copy:
+    src: "/tmp/ioncube/ioncube_loader_lin_7.1.so"
+    dest: "/usr/lib/php/20160303/"
+  tags: ioncube
+
+- name: Add Ioncube 7.1 as available php mod
+  become: yes
+  become_method: sudo
+  lineinfile: dest=/etc/php/7.1/mods-available/ioncube.ini line="zend_extension = /usr/lib/php/20160303/ioncube_loader_lin_7.1.so" create=yes state=present
+  tags: ioncube
+
+- name: Enable Ioncube for php 7.1
+  become: yes
+  become_method: sudo
+  file:
+    src: /etc/php/7.1/mods-available/ioncube.ini
+    dest: /etc/php/7.1/apache2/conf.d/0-ioncube.ini
+    state: link
+  tags: ioncube
+
+- name: Enable Ioncube for php 7.1 cli
+  become: yes
+  become_method: sudo
+  file:
+    src: /etc/php/7.1/mods-available/ioncube.ini
+    dest: /etc/php/7.1/cli/conf.d/0-ioncube.ini
+    state: link
+  tags: ioncube
+
+- name: Copy Ioncube 7.2
+  become: yes
+  become_method: sudo
+  copy:
+    src: "/tmp/ioncube/ioncube_loader_lin_7.2.so"
+    dest: "/usr/lib/php/20170718/"
+  tags: ioncube
+
+- name: Add Ioncube 7.2 as available php mod
+  become: yes
+  become_method: sudo
+  lineinfile: dest=/etc/php/7.2/mods-available/ioncube.ini line="zend_extension = /usr/lib/php/20170718/ioncube_loader_lin_7.2.so" create=yes state=present
+  tags: ioncube
+
+- name: Enable Ioncube for php 7.2
+  become: yes
+  become_method: sudo
+  file:
+    src: /etc/php/7.2/mods-available/ioncube.ini
+    dest: /etc/php/7.2/apache2/conf.d/0-ioncube.ini
+    state: link
+  tags: ioncube
+
+- name: Enable Ioncube for php 7.2 cli
+  become: yes
+  become_method: sudo
+  file:
+    src: /etc/php/7.2/mods-available/ioncube.ini
+    dest: /etc/php/7.2/cli/conf.d/0-ioncube.ini
+    state: link
+  tags: ioncube


### PR DESCRIPTION
I extended the ioncube task for PHP 7.1 and 7.2.
The downloaded tar.gz also provides ioncube for 7.3 which is not yet considered in the apache task.

```
vagrant@shop:~$ /usr/bin/php7.1 -v
PHP 7.1.33-2+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Nov 28 2019 07:41:45) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
    with the ionCube PHP Loader + ionCube24 v10.3.9, Copyright (c) 2002-2019, by ionCube Ltd.
    with Zend OPcache v7.1.33-2+ubuntu16.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
    with Xdebug v2.8.1, Copyright (c) 2002-2019, by Derick Rethans
vagrant@shop:~$ /usr/bin/php7.2 -v
PHP 7.2.25-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Nov 28 2019 07:41:59) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with the ionCube PHP Loader + ionCube24 v10.3.9, Copyright (c) 2002-2019, by ionCube Ltd.
    with Zend OPcache v7.2.25-1+ubuntu16.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
    with Xdebug v2.8.1, Copyright (c) 2002-2019, by Derick Rethans
```
