### PR TITLE
Add missing intl php module and change default php version to 7.2

### DIFF
--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -17,6 +17,7 @@
     - php5.6-simplexml
     - php5.6-xml
     - php5.6-zip
+    - php5.6-intl
 
     - libapache2-mod-php7.0
     - php7.0-cli
@@ -27,6 +28,7 @@
     - php7.0-simplexml
     - php7.0-xml
     - php7.0-zip
+    - php7.0-intl
 
     - libapache2-mod-php7.1
     - php7.1-cli
@@ -37,6 +39,7 @@
     - php7.1-simplexml
     - php7.1-xml
     - php7.1-zip
+    - php7.1-intl
 
     - libapache2-mod-php7.2
     - php7.2-cli
@@ -47,6 +50,7 @@
     - php7.2-simplexml
     - php7.2-xml
     - php7.2-zip
+    - php7.2-intl
 
     - php-apcu
     - php-xdebug
@@ -142,9 +146,10 @@
   become: yes
 
 - name: Set PHP version
-  command: /home/vagrant/bin/changephp_7.0
+  command: /home/vagrant/bin/changephp_7.2
   become: yes
 
 - name: be sure apache is started and enabled
   service: name=apache2 state=started enabled=yes
   become: yes
+


### PR DESCRIPTION
I've changed the php version to 7.2 by ran changephp_7.2 and ran install_shopware command.
During execution of install_shopware command i expected some strange error with composer here is a log:
```
Buildfile: /home/vagrant/www/shopware/build/build.xml

write-properties:
[propertyfile] Creating new property file: /home/vagrant/www/shopware/build/build.properties

BUILD SUCCESSFUL
Total time: 0 seconds
Unable to locate tools.jar. Expected to find it in /usr/lib/jvm/java-8-openjdk-amd64/lib/tools.jar
Buildfile: /home/vagrant/www/shopware/build/build.xml

check-composer-binary:

install-composer-binary:
     [exec] All settings correct for using Composer
     [exec] Downloading...
     [exec] 
     [exec] Composer (version 1.10.7) successfully installed to: /home/vagrant/www/shopware/composer.phar
     [exec] Use it: php composer.phar
     [exec] 

update-composer-binary:
     [exec] Updating to version 1 (stable channel).
     [exec] 
     [exec]                                                                                                                     
     [exec]   [Composer\Downloader\TransportException]                                                                          
     [exec]   The "https://getcomposer.org/download/1/composer.phar.sig" file could not be downloaded (HTTP/1.1 404 Not Found)  
     [exec]                                                                                                                     
     [exec] 
     [exec] self-update [-r|--rollback] [--clean-backups] [--no-progress] [--update-keys] [--stable] [--preview] [--snapshot] [--1] [--2] [--set-channel-only] [--] [<version>]
     [exec] 
     [exec] Result: 255

build-composer-install:
     [exec] Loading composer repositories with package information
     [exec] Installing dependencies (including require-dev) from lock file
     [exec] Your requirements could not be resolved to an installable set of packages.
     [exec] 
     [exec]   Problem 1
     [exec]     - The requested PHP extension ext-intl * is missing from your system. Install or enable PHP's intl extension.
     [exec] 

BUILD FAILED
/home/vagrant/www/shopware/build/build.xml:99: exec returned: 2

Total time: 21 seconds
```
It looks like new composer version need intl extension. I've added that inside my PR, and change default php version to 7.2 , as far i know 7.2 is the required minimum version for shopware
https://developers.shopware.com/sysadmins-guide/system-requirements/