### PR TITLE
Removed PHP 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,12 @@ Make sure GuestAdditions are same versions:
 
 The following PHP Versions are installed by default:
 
- - PHP 5.6
  - PHP 7.0
  - PHP 7.1
  - PHP 7.2
 
 Call one of the following commands to change the PHP Version:
  
-    $ changephp_5.6
     $ changephp_7.0
     $ changephp_7.1
     $ changephp_7.2
@@ -101,7 +99,6 @@ This will change the PHP Version used by the Apache webserver as well as the Ver
 
 You can also call the PHP versions directly using their full path
 
-    $ /usr/bin/php5.6 -v
     $ /usr/bin/php7.0 -v
     $ /usr/bin/php7.1 -v
     $ /usr/bin/php7.2 -v

--- a/ansible/playbook.retry
+++ b/ansible/playbook.retry
@@ -1,0 +1,1 @@
+default

--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -8,17 +8,6 @@
   apt: pkg={{ item }} state=present
   become: yes
   with_items:
-    - libapache2-mod-php5.6
-    - php5.6-cli
-    - php5.6-curl
-    - php5.6-gd
-    - php5.6-mysql
-    - php5.6-mbstring
-    - php5.6-simplexml
-    - php5.6-xml
-    - php5.6-zip
-    - php5.6-intl
-
     - libapache2-mod-php7.0
     - php7.0-cli
     - php7.0-curl
@@ -128,7 +117,6 @@
 - name: Configure PHP
   template: src={{ item.file }} dest=/etc/php/{{ item.phpversion }}/apache2/conf.d/{{ item.file }} owner=root group=root mode=0644
   with_items:
-    - { file: '99-debug.ini', phpversion: '5.6'}
     - { file: '99-debug.ini', phpversion: '7.0'}
     - { file: '99-debug.ini', phpversion: '7.1'}
     - { file: '99-debug.ini', phpversion: '7.2'}
@@ -139,7 +127,6 @@
 - name: Configure PHP-CLI
   template: src={{ item.file }} dest=/etc/php/{{ item.phpversion }}/cli/conf.d/{{ item.file }} owner=root group=root mode=0644
   with_items:
-    - { file: '99-debug.ini', phpversion: '5.6'}
     - { file: '99-debug.ini', phpversion: '7.0'}
     - { file: '99-debug.ini', phpversion: '7.1'}
     - { file: '99-debug.ini', phpversion: '7.2'}

--- a/ansible/roles/common/files/bin/changephp_5.6
+++ b/ansible/roles/common/files/bin/changephp_5.6
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -e
-sudo a2dismod php7.0 php7.1 php7.2
-sudo a2enmod php5.6
-sudo update-alternatives --set php /usr/bin/php5.6
-sudo service apache2 restart

--- a/ansible/roles/common/files/bin/changephp_7.0
+++ b/ansible/roles/common/files/bin/changephp_7.0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-sudo a2dismod php5.6 php7.1 php7.2
+sudo a2dismod php7.1 php7.2
 sudo a2enmod php7.0
 sudo update-alternatives --set php /usr/bin/php7.0
 sudo service apache2 restart

--- a/ansible/roles/common/files/bin/changephp_7.1
+++ b/ansible/roles/common/files/bin/changephp_7.1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-sudo a2dismod php5.6 php7.0 php7.2
+sudo a2dismod php7.0 php7.2
 sudo a2enmod php7.1
 sudo update-alternatives --set php /usr/bin/php7.1
 sudo service apache2 restart

--- a/ansible/roles/common/files/bin/changephp_7.2
+++ b/ansible/roles/common/files/bin/changephp_7.2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-sudo a2dismod php5.6 php7.0 php7.1
+sudo a2dismod php7.0 php7.1
 sudo a2enmod php7.2
 sudo update-alternatives --set php /usr/bin/php7.2
 sudo service apache2 restart

--- a/ansible/roles/ioncube/tasks/main.yml
+++ b/ansible/roles/ioncube/tasks/main.yml
@@ -8,38 +8,6 @@
   
 - name: Extract Ioncube
   unarchive: src=/tmp/ioncube_loaders_lin_x86-64.tar.gz dest=/tmp
-  
-- name: Copy Ioncube 5.6
-  become: yes
-  become_method: sudo
-  copy:
-    src: "/tmp/ioncube/ioncube_loader_lin_5.6.so"
-    dest: "/usr/lib/php/20131226/"
-  tags: ioncube
-    
-- name: Add Ioncube 5.6 as available php mod
-  become: yes
-  become_method: sudo
-  lineinfile: dest=/etc/php/5.6/mods-available/ioncube.ini line="zend_extension = /usr/lib/php/20131226/ioncube_loader_lin_5.6.so" create=yes state=present
-  tags: ioncube
-
-- name: Enable Ioncube for php 5.6
-  become: yes
-  become_method: sudo
-  file:
-    src: /etc/php/5.6/mods-available/ioncube.ini
-    dest: /etc/php/5.6/apache2/conf.d/0-ioncube.ini
-    state: link
-  tags: ioncube
-
-- name: Enable Ioncube for php 5.6 cli
-  become: yes
-  become_method: sudo
-  file:
-    src: /etc/php/5.6/mods-available/ioncube.ini
-    dest: /etc/php/5.6/cli/conf.d/0-ioncube.ini
-    state: link
-  tags: ioncube
 
 - name: Copy Ioncube 7.0
   become: yes


### PR DESCRIPTION
Fixes https://github.com/shopwareLabs/shopware-vagrant/issues/63

PHP 5.6 no longer seems to be available in the PPA repository.